### PR TITLE
Guard against error when the "do not challenge me" checkbox is not found

### DIFF
--- a/src/inject/okta-verify.js
+++ b/src/inject/okta-verify.js
@@ -13,11 +13,13 @@
 
   function getButton() {
     var button = findPushNotifButton() || findSendSMSButton();
+    var checkbox = findDoNotChallengeMeCheckbox();
+    
+    if (button && checkbox) {
+      checkbox.click();
+    }
 
     if (button) {
-      var checkbox = findDoNotChallengeMeCheckbox();
-
-      checkbox.click();
       button.click();
     } else {
       setTimeout(getButton, 100);


### PR DESCRIPTION
The "do not challenge me" checkbox doesn't always exist.