### PR TITLE
Auto-unfold Enter Code input

### DIFF
--- a/src/inject/okta-verify.js
+++ b/src/inject/okta-verify.js
@@ -27,4 +27,20 @@
   }
 
   getButton();
+  
+  function findEnterCodeLink() {
+    return document.querySelector('a[data-se="inline-totp-add"]');
+  }
+
+  function getLink() {
+    var link = findEnterCodeLink();
+
+    if (link) {
+      link.click();
+    } else {
+      setTimeout(getLink, 100);
+    }
+  }
+  
+  getLink();
 }());


### PR DESCRIPTION
In situation of unreliable connectivity, it may be faster to type the code manually. This additional function automatically clicks the "Or enter code" link to make the corresponding input field available immediately.

---

I realize that copy-pasting the code from above is not ideal. Please let me know if or how this suggestion should be refined. I imagine that folding it into the other function would be possible, without having much JS before, I'm not sure whether that would be sensible.